### PR TITLE
Fix plugin validation redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,11 @@ To view the log, open the `tmp.log` file.
     - SeleniumWebDriver
     - Visualizer
 
-    You can add custom elements in a `plugin-mappings.json` file (should be in root project folder path), as shown in below example.
-    ```js
-        {
+    You can add custom plugins in `config.yaml` file under Custom tag, as shown in below example.
+    ```yaml
+        Custom:
           "Plugin1": "org.Sample.plugin.name",
-          "DummySampler": 'kg.apc.jmeter.samplers.DummySampler'
-        }
+          "DummySampler": "kg.apc.jmeter.samplers.DummySampler"
     ```
 
 # 🛑 Limitations

--- a/README.md
+++ b/README.md
@@ -57,36 +57,52 @@ To view the log, open the `tmp.log` file.
 
 * JEval detects the JMeter version and validates the test plan.
 
-* JEval detects following JMeter elements
-  - AuthManager
-  - CookieManager
-  - HeaderManager
-  - CacheManager
-  - CSVDataSet  
-  - TransactionController  
-  - ConfigTestElement
-  - ConstantTimer
-  - UniformRandomTimer
-  - GaussianRandomTimer
-  - Arguments
-  - ProxyControl
-  - RegexExtractor
-  - TestAction
-  - BeanShellSampler
-  - JSR223Sampler
-  - IfController
-  - LoopController
-  - ResultCollector
-  - ResponseAssertion
-  - XPath2Assertion
-  - JSONPathAssertion
-  - DebugSampler
+* JEval detects following:
+ 
+    **JMeter elements**
+    - AuthManager
+    - CookieManager
+    - HeaderManager
+    - CacheManager
+    - CSVDataSet  
+    - TransactionController  
+    - ConfigTestElement
+    - ConstantTimer
+    - UniformRandomTimer
+    - GaussianRandomTimer
+    - Arguments
+    - ProxyControl
+    - RegexExtractor
+    - TestAction
+    - BeanShellSampler
+    - JSR223Sampler
+    - IfController
+    - LoopController
+    - ResultCollector
+    - ResponseAssertion
+    - XPath2Assertion
+    - JSONPathAssertion
+    - DebugSampler
 
-If you want to add custom elements, you can add it in the `config.yaml` file. 
+    If you want to add custom elements, you can add it in the `config.yaml` file. 
+
+    **JMeter (default) Plugins**
+    - DummySampler
+    - UDP
+    - SeleniumWebDriver
+    - Visualizer
+
+    You can add custom elements in a `plugin-mappings.json` file (should be in root project folder path), as shown in below example.
+    ```js
+        {
+          "Plugin1": "org.Sample.plugin.name",
+          "DummySampler": 'kg.apc.jmeter.samplers.DummySampler'
+        }
+    ```
 
 # 🛑 Limitations
 
-* Doesn't detect JMeter plugins yet.
+* TDB.
 
 # 💰 Donate
 ☕ <a target="_blank" href="https://www.buymeacoffee.com/qainsights">Buy me a tea</a>

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ To view the log, open the `tmp.log` file.
     You can add custom plugins in `config.yaml` file under Custom tag, as shown in below example.
     ```yaml
         Custom:
-          "Plugin1": "org.Sample.plugin.name",
-          "DummySampler": "kg.apc.jmeter.samplers.DummySampler"
+          Plugin1: org.Sample.plugin.name
+          DummySampler: kg.apc.jmeter.samplers.DummySampler
     ```
 
 # 🛑 Limitations
 
-* TDB.
+* TBD.
 
 # 💰 Donate
 ☕ <a target="_blank" href="https://www.buymeacoffee.com/qainsights">Buy me a tea</a>

--- a/app.py
+++ b/app.py
@@ -24,13 +24,25 @@ def main():
         )
         args = parser.parse_args()
         jmx = args.jmxfile
-        # load JEval config, this loads config.yaml to a global variable 'config'
-        config.load()
+
+        # Loads base configuration
+        load_configurations()
+
         with open(jmx) as f:
             parse_jmx(jmx)
+
     except FileNotFoundError as e:
         print_message(message_color=Colors.red, message=f"An error occured during JEval execution: "
                                                         f"{e.strerror} ({e.filename})")
+
+
+def load_configurations():
+    """
+     Load JEval config, this loads config.yaml to a global variable 'config'
+     Load custom plugin mappings
+    """
+    config.load()
+    config.load_plugin_mappings()
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -25,8 +25,8 @@ def main():
         args = parser.parse_args()
         jmx = args.jmxfile
 
-        # Loads base configuration
-        load_configurations()
+        # Loads base configuration from config.yaml
+        config.load()
 
         with open(jmx) as f:
             parse_jmx(jmx)
@@ -34,15 +34,6 @@ def main():
     except FileNotFoundError as e:
         print_message(message_color=Colors.red, message=f"An error occured during JEval execution: "
                                                         f"{e.strerror} ({e.filename})")
-
-
-def load_configurations():
-    """
-     Load JEval config, this loads config.yaml to a global variable 'config'
-     Load custom plugin mappings
-    """
-    config.load()
-    config.load_plugin_mappings()
 
 
 if __name__ == "__main__":

--- a/config.yaml
+++ b/config.yaml
@@ -36,8 +36,12 @@ JMeter:
   - BeanShellSampler
   #Official JMeter Plugins
   Plugins:
-  - DummySampler
-  - UDP
-  - SeleniumWebDriver
-  - Visualizer
+    Default:
+      - DummySampler
+      - UDP
+      - SeleniumWebDriver
+      - Visualizer
+    Custom:
+      # Add custom plugin mappings below here (key: value) - for details check README.md
+
   version: "5.3" #Update the latest version of JMeter

--- a/core/config.py
+++ b/core/config.py
@@ -1,7 +1,10 @@
 import yaml
+import json
+import os
 from core.engine import print_message, Colors
 
 config = None
+custom_plugin_mappings = None
 
 
 def load():
@@ -15,3 +18,30 @@ def load():
             config = yaml.safe_load(file)
         except yaml.YAMLError as e:
             print_message(message_color=Colors.red, message=e)
+
+
+def load_plugin_mappings():
+    """
+    Loads custom Jmeter plugin mappings from a json file
+    and sets to a global variable
+    """
+    global custom_plugin_mappings
+    filename = 'plugin-mappings.json'
+
+    if not (isinstance(filename, str) and os.path.exists and os.path.isfile(filename)):
+        return None
+
+    with open(filename, 'rb') as mapping_file:
+        data = json.loads(mapping_file)
+
+    if not isinstance(data, dict):
+        raise MalformedDataError()
+
+    custom_plugin_mappings = data
+
+    return None
+
+
+class MalformedDataError(Exception):
+    pass
+

--- a/core/config.py
+++ b/core/config.py
@@ -1,10 +1,7 @@
 import yaml
-import json
-import os
 from core.engine import print_message, Colors
 
 config = None
-custom_plugin_mappings = None
 
 
 def load():
@@ -14,34 +11,7 @@ def load():
     global config
     with open('config.yaml') as file:
         try:
-            # Reading Config file and parsing JMX (once)
+            # Reading Config file
             config = yaml.safe_load(file)
         except yaml.YAMLError as e:
             print_message(message_color=Colors.red, message=e)
-
-
-def load_plugin_mappings():
-    """
-    Loads custom Jmeter plugin mappings from a json file
-    and sets to a global variable
-    """
-    global custom_plugin_mappings
-    filename = 'plugin-mappings.json'
-
-    if not (isinstance(filename, str) and os.path.exists and os.path.isfile(filename)):
-        return None
-
-    with open(filename, 'rb') as mapping_file:
-        data = json.loads(mapping_file)
-
-    if not isinstance(data, dict):
-        raise MalformedDataError()
-
-    custom_plugin_mappings = data
-
-    return None
-
-
-class MalformedDataError(Exception):
-    pass
-

--- a/core/engine.py
+++ b/core/engine.py
@@ -4,7 +4,7 @@ from core.attribute_check import *
 from core import config as setup
 from utils.display import print_message, Colors
 from core.exceptions import Exceptions
-from core.plugins import get_plugin_full_name
+from core.plugins import PluginFactory
 
 
 def plugins_check(tree):
@@ -12,8 +12,10 @@ def plugins_check(tree):
     Checks for JMeter Plugins in JMeter
     @param tree: Parsed JMX file
     """
-    for plugin in setup.config['JMeter']['Plugins']:
-        plugin_full_name = get_plugin_full_name(plugin)
+    plugins_factory = PluginFactory()
+    plugins_factory.load_custom_plugin_mappings()
+    for plugin in plugins_factory.plugins:
+        plugin_full_name = plugins_factory.get_plugin_full_name(plugin)
         if plugin_full_name is not None:
             find_element_status(tree, plugin, plugin_full_name)
 
@@ -48,6 +50,9 @@ def find_element_status(tree, element, plugin_name=None):
         message = f"No plugin found for {plugin_name}."
         lookup_element = deepcopy(plugin_name)
 
+        if not count_node(root, lookup_element) > 0:
+            print_message(message_color=Colors.red, message=message)
+
     for node in root.iter(lookup_element):
         if node.attrib is None:
             print_message(message_color=Colors.red, message=message)
@@ -74,10 +79,7 @@ def count_node(root, element):
     @param element: the element to count to
     @return: the number of nodes as integer
     """
-    count = 0
-    for node in root.iter(element):
-        count += 1
-    return count
+    return len(list(root.iter(element)))
 
 
 def find_thread_groups(tree):

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -3,7 +3,7 @@ from utils.display import print_message
 
 
 class Exceptions:
-    
+
     @staticmethod
     def check(element, flag, enabled_count, message):
         """
@@ -30,23 +30,19 @@ class Exceptions:
             "Visualizer": Exceptions.jp_result_collector
         }
         # Get the exception to check from the list
-        exception_check = exception_list.get(element, Exceptions.default_choice(flag, message))
-        if exception_check is not None:
-            # Execute the function
-            exception_check(flag, enabled_count)
+        exception_check = exception_list.get(element, None)
+        exception_check(flag, enabled_count) if exception_check else Exceptions.default_choice(flag, message)
 
     @staticmethod
-    def jp_result_collector(flag, enabled_count):        
+    def jp_result_collector(flag, enabled_count):
         if flag:
             print_message(message_color=Colors.red, message=f"{enabled_count} Visualizer(s) enabled.")
-            print_message(message_color=Colors.white, message="Consider disabling Plugins Visualizer(s).")
+            print_message(message_color=Colors.white, message="Consider disabling Visualizer(s) plugins.")
         else:
             print_message(message_color=Colors.green, message=f"{enabled_count} Visualizer(s) are enabled.")
 
-
     @staticmethod
     def result_collector(flag, enabled_count):
-        
         if flag:
             print_message(message_color=Colors.red, message=f"{enabled_count} Listener(s) enabled.")
             print_message(message_color=Colors.white, message="Consider disabling Listeners.")

--- a/core/plugins.py
+++ b/core/plugins.py
@@ -1,0 +1,17 @@
+# dictionary to store default plugins short - long name mapping
+default_plugins_list = {
+    "DummySampler": 'kg.apc.jmeter.samplers.DummySampler',
+    'UDP': 'kg.apc.jmeter.samplers.UDPSampler',
+    'SeleniumWebDriver': 'com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler',
+    'Visualizer': 'kg.apc.jmeter.vizualizers.CorrectedResultCollector'
+}
+
+
+def get_plugin_full_name(plugin):
+    """
+    Returns the plugin full name based on plugin name/type
+    :param plugin: short name of plugin
+    :return: string long name of plugin
+    """
+    plugin_name = default_plugins_list.get(plugin, None)
+    return plugin_name

--- a/core/plugins.py
+++ b/core/plugins.py
@@ -1,17 +1,43 @@
-# dictionary to store default plugins short - long name mapping
-default_plugins_list = {
-    "DummySampler": 'kg.apc.jmeter.samplers.DummySampler',
-    'UDP': 'kg.apc.jmeter.samplers.UDPSampler',
-    'SeleniumWebDriver': 'com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler',
-    'Visualizer': 'kg.apc.jmeter.vizualizers.CorrectedResultCollector'
-}
+from core import config as setup
 
 
-def get_plugin_full_name(plugin):
-    """
-    Returns the plugin full name based on plugin name/type
-    :param plugin: short name of plugin
-    :return: string long name of plugin
-    """
-    plugin_name = default_plugins_list.get(plugin, None)
-    return plugin_name
+class PluginFactory:
+    def __init__(self):
+        # dictionary to store default plugins short - long name mapping
+        self.default_plugins = {
+            "DummySampler": 'kg.apc.jmeter.samplers.DummySampler',
+            'UDP': 'kg.apc.jmeter.samplers.UDPSampler',
+            'SeleniumWebDriver': 'com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler',
+            'Visualizer': 'kg.apc.jmeter.vizualizers.CorrectedResultCollector'
+        }
+        self.plugins = self.default_plugins
+        self.plugins_list = setup.config['JMeter']['Plugins']['Default']
+        self.custom_plugins = setup.config['JMeter']['Plugins']['Custom']
+
+    def load_custom_plugin_mappings(self):
+        """
+        Adds custom plugin mappings to default plugins dict
+        """
+        self.update_plugin_list()
+        if self.custom_plugins:
+            self.plugins.update(self.custom_plugins)
+
+    def update_plugin_list(self):
+        """
+        Generates a list of all plugin names (default + custom)
+        """
+        custom_plugin_list = []
+        if self.custom_plugins:
+            custom_plugin_list = [*self.custom_plugins]
+
+        self.plugins_list = list(set(self.plugins_list + custom_plugin_list))
+
+    def get_plugin_full_name(self, plugin):
+        """
+        Returns the plugin full name based on plugin name/type
+        :param plugin: short name of plugin
+        :return: string long name of plugin
+        """
+        # updated_plugin_list = load_custom_plugin_mappings(default_plugins_list)
+        plugin_name = self.plugins.get(plugin, None)
+        return plugin_name


### PR DESCRIPTION
Hey @QAInsights ,

PR to fix the redundancy plugin check logging and enhancements to support custom plugin loads via `config.yaml`

Change log:

**Bug fixes:**
- Fix plugin redundancy logs:
  - There was an issue with executing the default choice in switch case implementation using dictionary mapping, which was causing duplicate logging.

**Enhancements:**
- Plugin check is now moved into `plugins.py`, removed if condition checks.
- Supporting additional custom plugin load and checks from `config.yaml`:
  - Additional plugin checks can now be added to the tool from `config.yaml` directly and the tool will dynamically check for the new plugins in the .jmx file.
- Log if plugins listed in `config.yaml` are not present in jmx file.

**Refactoring**
- Minor wording changes in the documentation and log messages.
- Reused existing find element status function for plugin detection instead of duplicating the code. Removed the duplicate function.


Attached screenshot for before and after changes.

Cheer!
Prasad

![Capture](https://user-images.githubusercontent.com/47483946/95783349-45a39e80-0cef-11eb-882f-1556a1bc4df1.PNG)
